### PR TITLE
Cucumber test to confirm Tūranga Ararau can be found

### DIFF
--- a/features/search-examples.feature
+++ b/features/search-examples.feature
@@ -34,3 +34,8 @@ Scenario: I search for a phrase
   Given I enter "age concern" into the "keyword" input
   And I click on "Search"
   Then I see a "header" which says "Age Concern"
+
+Scenario: I search for a service provider with an address but no street number
+  Given I enter "Turanga" into the "keyword" input
+  And I search near the address "Gisborne"
+  Then a result is "Tūranga Ararau"

--- a/src/utilities/__tests__/geography.test.js
+++ b/src/utilities/__tests__/geography.test.js
@@ -78,6 +78,12 @@ describe('geography.js', () => {
       expect(checkLatLng([dataPointClone])).toMatchObject([]);
     });
 
+    it("accepts addresses which don't contain a street number", () => {
+      dataPointClone.PHYSICAL_ADDRESS = 'Cnr Jackson Street and South Terrace';
+
+      expect(checkLatLng([dataPointClone])).toMatchObject([dataPointClone]);
+    });
+
     it("responds null when latitude doesn't qualify", () => {
       dataPointClone.LATITUDE = null;
       expect(checkLatLng([dataPointClone])).toMatchObject([]);

--- a/src/utilities/__tests__/geography.test.js
+++ b/src/utilities/__tests__/geography.test.js
@@ -72,13 +72,13 @@ describe('geography.js', () => {
       expect(checkLatLng([dataPointClone])).toMatchObject([dataPointClone]);
     });
 
-    it("responds null when physical address doesn't qualify", () => {
+    it("accepts addresses when they are blank (Bug 185)", () => {
       dataPointClone.PHYSICAL_ADDRESS = '';
 
-      expect(checkLatLng([dataPointClone])).toMatchObject([]);
+      expect(checkLatLng([dataPointClone])).toMatchObject([dataPointClone]);
     });
 
-    it("accepts addresses which don't contain a street number", () => {
+    it("accepts addresses which don't contain a street number (Bug 185)", () => {
       dataPointClone.PHYSICAL_ADDRESS = 'Cnr Jackson Street and South Terrace';
 
       expect(checkLatLng([dataPointClone])).toMatchObject([dataPointClone]);

--- a/src/utilities/geography.js
+++ b/src/utilities/geography.js
@@ -31,7 +31,7 @@ const findNearMe = (data, addressLatLng, radius) => {
 const checkLatLng = data => {
   return data.filter(r => {
     return (
-      r.PHYSICAL_ADDRESS.match(/\d+/g) !== null &&
+      r.PHYSICAL_ADDRESS.match(/\S+/g) !== null &&
       r.LATITUDE !== '0' &&
       r.LONGITUDE !== '0' &&
       r.LATITUDE !== null &&

--- a/src/utilities/geography.js
+++ b/src/utilities/geography.js
@@ -31,7 +31,6 @@ const findNearMe = (data, addressLatLng, radius) => {
 const checkLatLng = data => {
   return data.filter(r => {
     return (
-      r.PHYSICAL_ADDRESS.match(/\S+/g) !== null &&
       r.LATITUDE !== '0' &&
       r.LONGITUDE !== '0' &&
       r.LATITUDE !== null &&


### PR DESCRIPTION
closes #201

A logic bug was found where services with an address not containing numbers would be interpreted as invalid for location searches. Paul agreed that we don't need to filter out search results based on their address regardless of how weird it looks or even if the address is missing.

The filtering logic will still remove results for location searches which don't include latitude and longitude.

The Jest tests have been updated to reflect the new logic for addresses

A Cucumber test has been added to check that a service with a problem address can be found in the live system. Note that some other Cucumber tests are currently broken due to recent UI changes.