### PR TITLE
Bug/searchinator delivering incomplete results  lyall

### DIFF
--- a/features/search-examples.feature
+++ b/features/search-examples.feature
@@ -44,3 +44,10 @@ Scenario: I search and find a lot of results, but only see the top 50 service pr
   Given I enter "Citizens Advice Bureau" into the "keyword" input
   And I click on "Magnifying Glass"
   Then I see exactly "50" service providers
+  And the search summary says "50"
+
+Scenario: I search and find 27 results, and see all of them displayed
+  Given I enter "Stand Children's Services" into the "keyword" input
+  And I click on "Magnifying Glass"
+  Then I see exactly "27" service providers
+  And the search summary says "27"

--- a/features/search-examples.feature
+++ b/features/search-examples.feature
@@ -39,3 +39,8 @@ Scenario: I search for a service provider with an address but no street number
   Given I enter "Turanga" into the "keyword" input
   And I search near the address "Gisborne"
   Then a result is "Tūranga Ararau"
+
+Scenario: I search and find a lot of results, but only see the top 50 service providers
+  Given I enter "Citizens Advice Bureau" into the "keyword" input
+  And I click on "Magnifying Glass"
+  Then I see exactly "50" service providers

--- a/features/step_definitions/main-page-steps.js
+++ b/features/step_definitions/main-page-steps.js
@@ -99,6 +99,10 @@ module.exports = function() {
     await driver.wait(until.elementsLocated(by.xpath(`//${elementType}//*[text()[contains(.,'${text}')]]`)), 10000);
   });
 
+  this.Given(/^the search summary says "([^"]*)"$/, async text => {
+    await driver.wait(until.elementsLocated(by.xpath(`//section[@class='search__criteria']//*[text()[contains(.,'${text}')]]`)), 10000);
+  });
+
   this.Then(/^I see a list of service providers$/, async () => {
     await driver.wait(until.elementsLocated(by.css('section .service')), 10000);
     const elements = await driver.findElements(by.css('section .service'));

--- a/features/step_definitions/main-page-steps.js
+++ b/features/step_definitions/main-page-steps.js
@@ -114,6 +114,13 @@ module.exports = function() {
     expect(elements.length).to.be.at.least(Number(num));
   });
 
+  this.Then(/^I see exactly "(\d+)" service providers$/, async num => {
+    await driver.wait(until.elementsLocated(by.css('section .service')), 10000);
+    const elements = await driver.findElements(by.css('section .service'));
+
+    expect(elements.length).to.equal(Number(num));
+  });
+
   this.Then(/^I click on the first address suggestion$/, async () => {
     await driver.wait(until.elementsLocated(by.css('#react-autowhatever-1--item-0')), 10000);
     const elements = await driver.findElements(by.css('#react-autowhatever-1--item-0'));

--- a/src/components/search-criteria.js
+++ b/src/components/search-criteria.js
@@ -12,15 +12,18 @@ export default class SearchCriteria extends Component {
     const { keyword, address, region, category, numOfResults, numOfResultsDisplayed } = this.props;
     const searchCriteria = createSearchCriteria(keyword, address, region, category);
 
-    return (<p>
-      {searchCriteria}
-      {' '}
-      {searchCriteria && 
-        <span>
-        ({numOfResultsDisplayed} results)
-        </span>
-      }
-      </p>);
+    return (
+      <section class="search__criteria">
+        <p>
+        {searchCriteria}
+        {' '}
+        {searchCriteria && 
+          <span>
+          ({numOfResultsDisplayed} results)
+          </span>
+        }
+        </p>
+      </section>);
   }
 }
 

--- a/src/components/search-criteria.js
+++ b/src/components/search-criteria.js
@@ -9,6 +9,7 @@ export default class SearchCriteria extends Component {
     If pagination of results is added in future numOfResults will become useful
     again to show the total number of results found across all pages, for
     example "Showing ${numOfResultsDisplayed} of {numOfResults} results". */
+    // eslint-disable-next-line no-unused-vars
     const { keyword, address, region, category, numOfResults, numOfResultsDisplayed } = this.props;
     const searchCriteria = createSearchCriteria(keyword, address, region, category);
 

--- a/src/components/search-criteria.js
+++ b/src/components/search-criteria.js
@@ -2,7 +2,14 @@ import React, { Component } from 'react';
 
 export default class SearchCriteria extends Component {
   render() {
-    const { keyword, address, region, category, numOfResults } = this.props;
+    /* Note that numOfResults is currently ignored, in favour of
+    numOfResultsDisplayed. This reflects the default limit of 50 search provider
+    results displayed in index.js. 
+
+    If pagination of results is added in future numOfResults will become useful
+    again to show the total number of results found across all pages, for
+    example "Showing ${numOfResultsDisplayed} of {numOfResults} results". */
+    const { keyword, address, region, category, numOfResults, numOfResultsDisplayed } = this.props;
     const searchCriteria = createSearchCriteria(keyword, address, region, category);
 
     return (<p>
@@ -10,7 +17,7 @@ export default class SearchCriteria extends Component {
       {' '}
       {searchCriteria && 
         <span>
-        ({numOfResults} results found)
+        ({numOfResultsDisplayed} results)
         </span>
       }
       </p>);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -104,7 +104,13 @@ export default class Index extends Component {
     loadResults(searchVars).then(res => {
       const unique_Results = uniqueServices(res, 'PUBLISHED_PHONE_1')
       const paged_results = unique_Results.slice(0, serviceProvidersPerPage)
-      this.setState({ serviceProviders: paged_results, userLatitude, userLongitude, numOfResults: unique_Results.length});
+      this.setState({ 
+        serviceProviders: paged_results, 
+        userLatitude, 
+        userLongitude, 
+        numOfResults: unique_Results.length, 
+        numOfResultsDisplayed: paged_results.length
+      });
     });
   }
   showToggleMapButton(showExtraButtons) {
@@ -122,7 +128,7 @@ export default class Index extends Component {
   }
 
   render() {
-    const { serviceProviders, showMap, address, region, keyword, radius, numOfResults} = this.state;
+    const { serviceProviders, showMap, address, region, keyword, radius, numOfResults, numOfResultsDisplayed} = this.state;
     const { history, location, categoryContext: {selectedCategory} } = this.props;
 
     const searchVars = queryString.parse(location.search);
@@ -148,6 +154,7 @@ export default class Index extends Component {
           region={region}
           category={selectedCategory}
           numOfResults={numOfResults}
+          numOfResultsDisplayed={numOfResultsDisplayed}
         />
         {this.showToggleMapButton(showExtraButtons)}
         {showMap ? (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -83,7 +83,7 @@ export default class Index extends Component {
 
     push(`${location.pathname}?${newSearchQuery}`);
   }
-  doLoadResults(locationQuery) {
+  doLoadResults(locationQuery, serviceProvidersPerPage = 50) {
     const {
       categoryContext: { setCategory },
     } = this.props;
@@ -103,7 +103,8 @@ export default class Index extends Component {
 
     loadResults(searchVars).then(res => {
       const unique_Results = uniqueServices(res, 'PUBLISHED_PHONE_1')
-      this.setState({ serviceProviders: unique_Results, userLatitude, userLongitude, numOfResults: unique_Results.length});
+      const paged_results = unique_Results.slice(0, serviceProvidersPerPage)
+      this.setState({ serviceProviders: paged_results, userLatitude, userLongitude, numOfResults: unique_Results.length});
     });
   }
   showToggleMapButton(showExtraButtons) {


### PR DESCRIPTION
Changes the search results list to only show a configurable number of service provider results (default 50).

This relates to Dana's change to increase the search `limit` to 500 services from 50, which also increased the number of results shown on the page.

Also updated the search criteria section to show the number of service providers displayed rather than the total number present in the search results so users aren't confused if there are more than 50 service providers but only 50 are displayed.

Ideally we'd implement some result pagination so users could choose to see the full result set. These changes are compatible with that goal.

Cucumber tests have been added to test that
1 - when there are more than 50 results only 50 are displayed, and the search criteria section says there are 50
2 - when there are less than 50 results they are all displayed and the search criteria section says there are the correct number.