### PR TITLE
Require chromedriver (used by cucumber tests)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4490,9 +4490,9 @@
       }
     },
     "chromedriver": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.45.0.tgz",
-      "integrity": "sha512-Qwmcr+2mU3INeR6mVsQ8gO00vZpL8ZeTJLclX44C0dcs88jrSDgckPqbG+qkVX+m2L/aOPnF0lYgPdOiOiLt5w==",
+      "version": "74.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-74.0.0.tgz",
+      "integrity": "sha512-xXgsq0l4gVTY9X5vuccOSVj/iEBm3Bf5MIwzSAASIRJagt4BlWw77SxQq1f4JAJ35/9Ys4NLMA/kWFbd7A/gfQ==",
       "dev": true,
       "requires": {
         "del": "^3.0.0",
@@ -19341,6 +19341,19 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
+          }
+        },
+        "chromedriver": {
+          "version": "2.46.0",
+          "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.46.0.tgz",
+          "integrity": "sha512-dLtKIJW3y/PuFrPmcw6Mb8Nh+HwSqgVrK1rWgTARXhHfWvV822X2VRkx2meU/tg2+YQL6/nNgT6n5qWwIDHbwg==",
+          "dev": true,
+          "requires": {
+            "del": "^3.0.0",
+            "extract-zip": "^1.6.7",
+            "mkdirp": "^0.5.1",
+            "request": "^2.88.0",
+            "tcp-port-used": "^1.0.1"
           }
         },
         "commander": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "chromedriver": "^74.0.0",
     "gh-pages": "^2.0.1",
     "selenium-cucumber-js": "^1.6.2"
   }


### PR DESCRIPTION
Adds an explicit dependency on chromedriver, which is used to run the cucumber tests. I found that my existing version of chromedriver was outdated and npm wasn't interested in updating it automatically.