### PR TITLE
Improve display of long provider descriptions on mobile

### DIFF
--- a/features/search-examples.feature
+++ b/features/search-examples.feature
@@ -46,8 +46,8 @@ Scenario: I search and find a lot of results, but only see the top 50 service pr
   Then I see exactly "50" service providers
   And the search summary says "50"
 
-Scenario: I search and find 27 results, and see all of them displayed
+Scenario: I search and find 28 results, and see all of them displayed
   Given I enter "Stand Children's Services" into the "keyword" input
   And I click on "Magnifying Glass"
-  Then I see exactly "27" service providers
-  And the search summary says "27"
+  Then I see exactly "28" service providers
+  And the search summary says "28"

--- a/features/step_definitions/search-steps.js
+++ b/features/step_definitions/search-steps.js
@@ -66,16 +66,15 @@ module.exports = function() {
       // suggestions where the next character should be a comma.
       input_elements[0].sendKeys(' \b');
 
-      await driver.wait(until.elementsLocated(by.xpath(`//*[@id='react-autowhatever-1--item-0']//div[contains(text(), '${value}')]`)), 10000);
-      
-      elements = await driver.findElements(by.xpath(`//*[@id='react-autowhatever-1--item-0']//div[contains(text(), '${value}')]`));
+      elements = await driver.wait(until.elementsLocated(by.xpath(`//*[@id='react-autowhatever-1--item-0']//div[contains(text(), '${value}')]`)), 10000);
 
       // There's a chance that still no element has been found, but that hasn't
       // been observed.
     }
 
     elements[0].click();
-    await driver.sleep(500);
+    
+    await driver.wait(until.stalenessOf(elements[0]));
   });
 
   this.When(/^the address box is empty$/, async () => {

--- a/src/assets/scss/components/_service.scss
+++ b/src/assets/scss/components/_service.scss
@@ -24,6 +24,13 @@
     margin: 0 0 1rem;
     padding: 0.5rem 0.5rem 0.5rem 1rem;
     border-left: 0.125rem solid $secondary-color;
+    white-space: pre-wrap;
+    &--truncate {
+      @media only screen and (max-width: 767px) {
+        overflow: scroll;
+        max-height: 250px;
+      }
+    }
   }
 
   &__page {

--- a/src/assets/scss/components/_service.scss
+++ b/src/assets/scss/components/_service.scss
@@ -25,10 +25,11 @@
     padding: 0.5rem 0.5rem 0.5rem 1rem;
     border-left: 0.125rem solid $secondary-color;
     white-space: pre-wrap;
+
     &--truncatable {
       @media only screen and (max-width: 767px) {
         overflow: scroll;
-        max-height: 250px;
+        max-height: 18rem;
       }
     }
   }

--- a/src/assets/scss/components/_service.scss
+++ b/src/assets/scss/components/_service.scss
@@ -25,7 +25,7 @@
     padding: 0.5rem 0.5rem 0.5rem 1rem;
     border-left: 0.125rem solid $secondary-color;
     white-space: pre-wrap;
-    &--truncate {
+    &--truncatable {
       @media only screen and (max-width: 767px) {
         overflow: scroll;
         max-height: 250px;

--- a/src/components/search-criteria.js
+++ b/src/components/search-criteria.js
@@ -14,7 +14,7 @@ export default class SearchCriteria extends Component {
     const searchCriteria = createSearchCriteria(keyword, address, region, category);
 
     return (
-      <section class="search__criteria">
+      <section className="search__criteria">
         <p>
         {searchCriteria}
         {' '}
@@ -32,13 +32,13 @@ function createSearchCriteria(keyword, address, region, category) {
   const search = ['Searching'];
 
   if (keyword) search.push(
-      <span>{' '} for: <b>{keyword}</b>{' '}</span>,
+      <span key={`k:${keyword}`}>{' '} for: <b>{keyword}</b>{' '}</span>,
     );
   if (address || region) search.push(
-      <span key={address || region}>{' '} near: <b>{address || region}</b></span>,
+      <span key={`a:${address || region}`}>{' '} near: <b>{address || region}</b></span>,
     );
   if (category) search.push(
-      <span>{' '} in: <b>{category}</b></span>,
+      <span key={`c:${category}`}>{' '} in: <b>{category}</b></span>,
     );
   if (search.length < 2) return null;
 

--- a/src/components/service-classification.js
+++ b/src/components/service-classification.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+
+export default class ServiceClassification extends Component {
+  static propTypes = {
+    classification: PropTypes.string,
+  };
+
+  render() {
+    const { classification } = this.props;
+
+    return (
+      <div className="icon-prefix__container">
+        <div className="icon-prefix__icon">
+          <Icon icon={faFolderOpen} />
+        </div>
+        <div className="icon-prefix__label">
+          <a href={`https://www.familyservices.govt.nz/directory-help/classifications.html`}>
+            {classification.split(',').join(', ')}
+          </a>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/service-classification.js
+++ b/src/components/service-classification.js
@@ -18,7 +18,7 @@ export default class ServiceClassification extends Component {
         </div>
         <div className="icon-prefix__label">
           <a href={`https://www.familyservices.govt.nz/directory-help/classifications.html`}>
-            {classification.split(',').join(', ')}
+            {classification && classification.split(',').join(', ')}
           </a>
         </div>
       </div>

--- a/src/components/service-details.js
+++ b/src/components/service-details.js
@@ -4,26 +4,21 @@ import { AccordionItem, AccordionItemTitle, AccordionItemBody } from 'react-acce
 
 export default class Service extends Component {
   static propTypes = {
-    costType: PropTypes.string.isRequired,
-    costDescription: PropTypes.string,
-    deliveryMethods: PropTypes.string,
-    expanded: PropTypes.bool,
-    serviceReferrals: PropTypes.string,
-    serviceDetail: PropTypes.string,
-    serviceName: PropTypes.string,
-    targetAudiences: PropTypes.string,
+    service: PropTypes.object.isRequired,
   };
 
   render() {
     const {
-      costType,
-      costDescription,
-      deliveryMethods,
       expanded,
-      targetAudiences,
-      serviceName,
-      serviceReferrals,
-      serviceDetail,
+      service: {
+        COST_TYPE: costType,
+        COST_DESCRIPTION: costDescription,
+        DELIVERY_METHODS: deliveryMethods,
+        SERVICE_TARGET_AUDIENCES: targetAudiences,
+        SERVICE_NAME: serviceName,
+        SERVICE_REFERRALS: serviceReferrals,
+        SERVICE_DETAIL: serviceDetail,
+      }
     } = this.props;
 
     return (

--- a/src/components/service-header.js
+++ b/src/components/service-header.js
@@ -1,0 +1,127 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { FontAwesomeIcon as Icon } from '@fortawesome/react-fontawesome';
+import { faLink, faClock, faPhone, faMapMarkerAlt, faAt } from '@fortawesome/free-solid-svg-icons';
+import queryString from 'query-string';
+
+import { stripSpaces } from '../utilities/string';
+import SaveContact from './save-contact';
+
+export default class ServiceHeader extends Component {
+  static propTypes = {
+    fsdId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    address: PropTypes.string,
+    contactAvailability: PropTypes.string,
+    name: PropTypes.string.isRequired,
+    website: PropTypes.string,
+    email: PropTypes.string,
+    phoneNumber: PropTypes.string,
+  };
+
+  render() {
+    const {
+      fsdId,
+      address,
+      contactAvailability,
+      name,
+      website,
+      email,
+      phoneNumber,
+      userLatitude,
+      userLongitude,
+      providerLatitude,
+      providerLongitude
+    } = this.props;
+
+    // The location of the user, if supplied. Used as the origin when preparing
+    // directions to the provider. The coordinates will be passed through to the
+    // service detail page in the URL query string, although other query string
+    // values will not.
+    const userCoordinates = (userLatitude && userLongitude)
+      ? queryString.stringify({ latitude: userLatitude, longitude: userLongitude })
+      : null;
+
+    // The url to use for directions to the provider. 
+    //
+    // Happily if the user location is not available we can still populate the
+    // destination and the user just needs to put their own address into Google.
+    const directionsUrl = (userLatitude && userLongitude)
+      ? `https://www.google.com/maps/dir/${userLatitude},${userLongitude}/${providerLatitude},${providerLongitude}`
+      : `https://www.google.com/maps/dir//${providerLatitude},${providerLongitude}`
+
+    return (
+      <header className="service__header">
+        <h2 className="service__name">
+          <Link to={{
+            pathname: `/service/${fsdId}`, 
+            search: userCoordinates
+            }}>
+              {name}
+          </Link>
+        </h2>
+        <address className="service__address">
+          {address && (
+            <div className="icon-prefix__container">
+              <div className="icon-prefix__icon">
+                <Icon icon={faMapMarkerAlt} />
+              </div>
+              <div className="icon-prefix__label">
+                {address} - <a href={directionsUrl}>Directions</a>
+              </div>
+            </div>
+          )}
+          {website && (
+            <div className="icon-prefix__container">
+              <div className="icon-prefix__icon">
+                <Icon icon={faLink} />
+              </div>
+              <a className="icon-prefix__label" href={website} target="_blank" rel="noopener noreferrer">
+                {website}
+              </a>
+            </div>
+          )}
+          {contactAvailability && (
+            <div className="icon-prefix__container">
+              <div className="icon-prefix__icon">
+                <Icon icon={faClock} />
+              </div>
+              <div className="icon-prefix__label">{contactAvailability}</div>
+            </div>
+          )}
+          {email && (
+            <div className="icon-prefix__container">
+              <div className="icon-prefix__icon">
+                <Icon icon={faAt} />
+              </div>
+              <a className="icon-prefix__label" href={`mailto:${email}`} target="_blank" rel="noopener noreferrer">
+                {email}
+              </a>
+            </div>
+          )}
+          {phoneNumber && (
+            <div className="icon-prefix__container">
+              <div className="icon-prefix__icon">
+                <Icon icon={faPhone} />
+              </div>
+              <a
+                className="icon-prefix__label"
+                href={`tel:${stripSpaces(phoneNumber)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {phoneNumber}
+              </a>
+            </div>
+          )}
+          <SaveContact
+            name={name}
+            phoneNumber={phoneNumber}
+            address={address}
+            email={email}
+            />
+        </address>
+      </header>
+    );
+  }
+}

--- a/src/components/service-header.js
+++ b/src/components/service-header.js
@@ -10,28 +10,26 @@ import SaveContact from './save-contact';
 
 export default class ServiceHeader extends Component {
   static propTypes = {
-    fsdId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-    address: PropTypes.string,
-    contactAvailability: PropTypes.string,
-    name: PropTypes.string.isRequired,
-    website: PropTypes.string,
-    email: PropTypes.string,
-    phoneNumber: PropTypes.string,
+    provider: PropTypes.object.isRequired,
+    userLatitude: PropTypes.string,
+    userLongitude: PropTypes.string
   };
 
   render() {
     const {
-      fsdId,
-      address,
-      contactAvailability,
-      name,
-      website,
-      email,
-      phoneNumber,
+      provider: {
+        FSD_ID: fsdId,
+        PROVIDER_NAME: name,
+        PHYSICAL_ADDRESS: address,
+        PROVIDER_CONTACT_AVAILABILITY: availability,
+        PROVIDER_WEBSITE_1: website,
+        PUBLISHED_CONTACT_EMAIL_1: email,
+        PUBLISHED_PHONE_1: phone,
+        LATITUDE: latitude, 
+        LONGITUDE: longitude
+      },
       userLatitude,
-      userLongitude,
-      providerLatitude,
-      providerLongitude
+      userLongitude
     } = this.props;
 
     // The location of the user, if supplied. Used as the origin when preparing
@@ -47,8 +45,8 @@ export default class ServiceHeader extends Component {
     // Happily if the user location is not available we can still populate the
     // destination and the user just needs to put their own address into Google.
     const directionsUrl = (userLatitude && userLongitude)
-      ? `https://www.google.com/maps/dir/${userLatitude},${userLongitude}/${providerLatitude},${providerLongitude}`
-      : `https://www.google.com/maps/dir//${providerLatitude},${providerLongitude}`
+      ? `https://www.google.com/maps/dir/${userLatitude},${userLongitude}/${latitude},${longitude}`
+      : `https://www.google.com/maps/dir//${latitude},${longitude}`
 
     return (
       <header className="service__header">
@@ -81,12 +79,12 @@ export default class ServiceHeader extends Component {
               </a>
             </div>
           )}
-          {contactAvailability && (
+          {availability && (
             <div className="icon-prefix__container">
               <div className="icon-prefix__icon">
                 <Icon icon={faClock} />
               </div>
-              <div className="icon-prefix__label">{contactAvailability}</div>
+              <div className="icon-prefix__label">{availability}</div>
             </div>
           )}
           {email && (
@@ -99,24 +97,24 @@ export default class ServiceHeader extends Component {
               </a>
             </div>
           )}
-          {phoneNumber && (
+          {phone && (
             <div className="icon-prefix__container">
               <div className="icon-prefix__icon">
                 <Icon icon={faPhone} />
               </div>
               <a
                 className="icon-prefix__label"
-                href={`tel:${stripSpaces(phoneNumber)}`}
+                href={`tel:${stripSpaces(phone)}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {phoneNumber}
+                {phone}
               </a>
             </div>
           )}
           <SaveContact
             name={name}
-            phoneNumber={phoneNumber}
+            phoneNumber={phone}
             address={address}
             email={email}
             />

--- a/src/components/service-provider-result.js
+++ b/src/components/service-provider-result.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-
 import ServiceHeader from './service-header';
 import ServiceClassification from './service-classification';
 
-export default class ServiceProviders extends Component {
+export default class ServiceProviderResult extends Component {
   static propTypes = {
+    index: PropTypes.number,
     fsdId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     purpose: PropTypes.string,
     address: PropTypes.string,
@@ -21,6 +21,7 @@ export default class ServiceProviders extends Component {
 
   render() {
     const {
+      index,
       fsdId,
       purpose,
       address,
@@ -37,12 +38,12 @@ export default class ServiceProviders extends Component {
     } = this.props;
 
     return (
-      <section className="service">
+      <section className="service" result-index={index}>
         <ServiceHeader
           fsdId={fsdId}
           address={address}
           contactAvailability={contactAvailability}
-          name={name}
+          name={process.env.REACT_APP_DISPLAY_INDEX ? `${index+1}. ${name}` : name}
           website={website}
           email={email}
           phoneNumber={phoneNumber}
@@ -52,7 +53,11 @@ export default class ServiceProviders extends Component {
           providerLongitude={providerLongitude}
         />
 
-        {purpose && <blockquote className="service__purpose">{purpose}</blockquote>}
+        {purpose && 
+          <blockquote className="service__purpose service__purpose--truncate">
+            {purpose}
+          </blockquote>
+        }
 
         <footer className="service__footer">
           {classification && 

--- a/src/components/service-provider-result.js
+++ b/src/components/service-provider-result.js
@@ -7,62 +7,36 @@ import ServiceClassification from './service-classification';
 export default class ServiceProviderResult extends Component {
   static propTypes = {
     index: PropTypes.number,
-    fsdId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-    purpose: PropTypes.string,
-    address: PropTypes.string,
-    classification: PropTypes.string,
-    contactAvailability: PropTypes.string,
-    name: PropTypes.string.isRequired,
-    website: PropTypes.string,
-    email: PropTypes.string,
-    phoneNumber: PropTypes.string,
-    hideMoreDetails: PropTypes.bool,
+    provider: PropTypes.object.isRequired,
+    userLatitude: PropTypes.string,
+    userLongitude: PropTypes.string
   };
 
   render() {
     const {
       index,
-      fsdId,
-      purpose,
-      address,
-      classification,
-      contactAvailability,
-      name,
-      website,
-      email,
-      phoneNumber,
+      provider,
+      provider: {
+        PROVIDER_CLASSIFICATION: classification,
+        ORGANISATION_PURPOSE: purpose,
+      },
       userLatitude,
       userLongitude,
-      providerLatitude,
-      providerLongitude
     } = this.props;
 
     return (
       <section className="service" result-index={index}>
+        {process.env.REACT_APP_DISPLAY_INDEX && index+1 }
         <ServiceHeader
-          fsdId={fsdId}
-          address={address}
-          contactAvailability={contactAvailability}
-          name={process.env.REACT_APP_DISPLAY_INDEX ? `${index+1}. ${name}` : name}
-          website={website}
-          email={email}
-          phoneNumber={phoneNumber}
+          provider={provider}
           userLatitude={userLatitude}
           userLongitude={userLongitude}
-          providerLatitude={providerLatitude}
-          providerLongitude={providerLongitude}
         />
 
-        {purpose && 
-          <blockquote className="service__purpose service__purpose--truncate">
-            {purpose}
-          </blockquote>
-        }
+        {purpose && <blockquote className="service__purpose service__purpose--truncatable">{purpose}</blockquote>}
 
         <footer className="service__footer">
-          {classification && 
-            <ServiceClassification classification={classification} />
-          }
+          {classification && <ServiceClassification classification={classification} />}
         </footer>
       </section>
     );

--- a/src/components/service-provider.js
+++ b/src/components/service-provider.js
@@ -7,57 +7,36 @@ import ServiceClassification from './service-classification';
 
 export default class ServiceProviders extends Component {
   static propTypes = {
-    fsdId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-    purpose: PropTypes.string,
-    address: PropTypes.string,
-    classification: PropTypes.string,
-    contactAvailability: PropTypes.string,
-    name: PropTypes.string.isRequired,
-    website: PropTypes.string,
-    email: PropTypes.string,
-    phoneNumber: PropTypes.string,
-    hideMoreDetails: PropTypes.bool,
+    provider: PropTypes.object.isRequired,
+    userLatitude: PropTypes.string,
+    userLongitude: PropTypes.string
   };
 
   render() {
     const {
-      fsdId,
-      purpose,
-      address,
-      classification,
-      contactAvailability,
-      name,
-      website,
-      email,
-      phoneNumber,
+      provider,
+      provider: {
+        PROVIDER_CLASSIFICATION: classification,
+        ORGANISATION_PURPOSE: purpose,
+      },
       userLatitude,
       userLongitude,
-      providerLatitude,
-      providerLongitude
     } = this.props;
 
     return (
       <section className="service">
         <ServiceHeader
-          fsdId={fsdId}
-          address={address}
-          contactAvailability={contactAvailability}
-          name={name}
-          website={website}
-          email={email}
-          phoneNumber={phoneNumber}
+          provider={provider}
           userLatitude={userLatitude}
           userLongitude={userLongitude}
-          providerLatitude={providerLatitude}
-          providerLongitude={providerLongitude}
         />
 
-        {purpose && <blockquote className="service__purpose">{purpose}</blockquote>}
+        {purpose && <blockquote className="service__purpose">
+            {purpose}
+          </blockquote>}
 
         <footer className="service__footer">
-          {classification && 
-            <ServiceClassification classification={classification} />
-          }
+          {classification && <ServiceClassification classification={classification} />}
         </footer>
       </section>
     );

--- a/src/containers/list-of-service-providers.js
+++ b/src/containers/list-of-service-providers.js
@@ -1,7 +1,7 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import ServiceProvider from '../components/service-provider';
+import ServiceProviderResult from '../components/service-provider-result';
 import uniqueServices from '../utilities/uniqueServices';
 
 export default class ListOfServiceProviders extends Component {
@@ -20,10 +20,9 @@ export default class ListOfServiceProviders extends Component {
       return (
         <section className="service__container">          
         {uniqueServices(serviceProviders, 'PROVIDER_NAME').map((provider, index) => (
-          <Fragment>
-            {process.env.REACT_APP_DISPLAY_INDEX && <h3>{index+1}</h3>}
-            <ServiceProvider
-              key={`service_${index}`}
+            <ServiceProviderResult
+              key={provider.FSD_ID} 
+              index={index}
               fsdId={provider.FSD_ID}
               purpose={provider.ORGANISATION_PURPOSE}
               address={provider.PHYSICAL_ADDRESS}
@@ -38,7 +37,6 @@ export default class ListOfServiceProviders extends Component {
               userLatitude={userLatitude}
               userLongitude={userLongitude}
             />
-          </Fragment>
           ))}
         </section>
       );

--- a/src/containers/list-of-service-providers.js
+++ b/src/containers/list-of-service-providers.js
@@ -7,6 +7,8 @@ import uniqueServices from '../utilities/uniqueServices';
 export default class ListOfServiceProviders extends Component {
   static propTypes = {
     serviceProviders: PropTypes.array.isRequired,
+    userLatitude: PropTypes.string,
+    userLongitude: PropTypes.string
   };
 
   render() {
@@ -19,21 +21,12 @@ export default class ListOfServiceProviders extends Component {
     if (serviceProviders.length > 0) {
       return (
         <section className="service__container">          
-        {uniqueServices(serviceProviders, 'PROVIDER_NAME').map((provider, index) => (
+        {uniqueServices(serviceProviders, 'PROVIDER_NAME')
+          .map((provider, index) => (
             <ServiceProviderResult
               key={provider.FSD_ID} 
               index={index}
-              fsdId={provider.FSD_ID}
-              purpose={provider.ORGANISATION_PURPOSE}
-              address={provider.PHYSICAL_ADDRESS}
-              classification={provider.PROVIDER_CLASSIFICATION}
-              contactAvailability={provider.PROVIDER_CONTACT_AVAILABILITY}
-              name={provider.PROVIDER_NAME}
-              website={provider.PROVIDER_WEBSITE_1}
-              email={provider.PUBLISHED_CONTACT_EMAIL_1}
-              phoneNumber={provider.PUBLISHED_PHONE_1}
-              providerLatitude={provider.LATITUDE}
-              providerLongitude={provider.LONGITUDE}
+              provider={provider}
               userLatitude={userLatitude}
               userLongitude={userLongitude}
             />

--- a/src/pages/service.js
+++ b/src/pages/service.js
@@ -13,6 +13,7 @@ import uniqueServices from '../utilities/uniqueServices';
 
 export default class Service extends Component {
   state = {
+    provider: null,
     purpose: '',
     address: '',
     classification: '',
@@ -53,6 +54,7 @@ export default class Service extends Component {
 
       this.setState({
         loading: false,
+        provider: provider,
         purpose: provider.ORGANISATION_PURPOSE,
         address: provider.PHYSICAL_ADDRESS,
         classification: provider.PROVIDER_CLASSIFICATION,
@@ -80,6 +82,7 @@ export default class Service extends Component {
     } = this.props;
     const {
       loading,
+      provider,
       purpose,
       address,
       classification,
@@ -122,20 +125,9 @@ export default class Service extends Component {
           {!loading && (
             <Fragment>
               <ServiceProvider
-                fsdId={id}
-                purpose={purpose}
-                address={address}
-                classification={classification}
-                contactAvailability={contactAvailability}
-                name={name}
-                website={website}
-                email={email}
-                phoneNumber={phoneNumber}
-                hideMoreDetails={true}
+                provider={provider}
                 userLatitude={userLatitude}
                 userLongitude={userLongitude}
-                providerLatitude={providerLatitude}
-                providerLongitude={providerLongitude}
               />
               <Accordion>
                 {services.map((service, i) => {

--- a/src/pages/service.js
+++ b/src/pages/service.js
@@ -14,107 +14,45 @@ import uniqueServices from '../utilities/uniqueServices';
 export default class Service extends Component {
   state = {
     provider: null,
-    purpose: '',
-    address: '',
-    classification: '',
-    contactAvailability: '',
-    name: '',
-    website: '',
-    email: '',
-    phoneNumber: '',
-
-    serviceDetail: '',
-
+    services: [],
     userLatitude: '',
     userLongitude: '',
-    providerLatitude: '',
-    providerLongitude: '',
-
-    loading: true,
   };
 
-  doParseUrl = () => {
-    const { search } = this.props.location;
+  componentDidMount = async () => {
     const { 
-      latitude = '', 
-      longitude = ''
-    } = queryString.parse(search);;
+      userLatitude, 
+      userLongitude,
+    } = queryString.parse(this.props.location.search);
+
+    const {
+      provider, 
+      services
+    } = await loadService(this.props.match.params.id)
 
     this.setState({
-      userLatitude: latitude,
-      userLongitude: longitude
+      provider: provider,
+      services: uniqueServices(services, 'SERVICE_NAME'),
+      userLatitude,
+      userLongitude,
     });
-  };
-
-  componentDidMount = () => {
-    const { id } = this.props.match.params;
- 
-    loadService(id).then(args => {
-      const { provider, services } = args;
-
-      this.setState({
-        loading: false,
-        provider: provider,
-        purpose: provider.ORGANISATION_PURPOSE,
-        address: provider.PHYSICAL_ADDRESS,
-        classification: provider.PROVIDER_CLASSIFICATION,
-        contactAvailability: provider.PROVIDER_CONTACT_AVAILABILITY,
-        name: provider.PROVIDER_NAME,
-        website: provider.PROVIDER_WEBSITE_1,
-        email: provider.PUBLISHED_CONTACT_EMAIL_1,
-        phoneNumber: provider.PUBLISHED_PHONE_1,
-        services: uniqueServices(services, 'SERVICE_NAME'),
-
-        providerLatitude: provider.LATITUDE,
-        providerLongitude: provider.LONGITUDE,
-      });
-    });
-
-    this.doParseUrl();
   };
 
   render() {
     const {
-      match: {
-        params: { id },
-      },
       history: { goBack },
     } = this.props;
-    const {
-      loading,
-      provider,
-      purpose,
-      address,
-      classification,
-      contactAvailability,
-      name,
-      website,
-      email,
-      phoneNumber,
-      services,
 
+    const {
+      provider,
+      services,
       userLatitude,
       userLongitude,
-      providerLatitude,
-      providerLongitude,
     } = this.state;
 
-    const providerMap =
-      providerLatitude && providerLongitude ? (
-        <MapContainer
-          serviceProviders={[{
-            PROVIDER_NAME: name,
-            ORGANISATION_PURPOSE: purpose,
-            PHYSICAL_ADDRESS: address,
-            LATITUDE: providerLatitude,
-            LONGITUDE: providerLongitude
-          }]}
-        />
-      ) : null;
-    
     return (
       <Page className="service__page">
-        <header>
+        <section>
           <button className="icon-prefix__container button back-button" onClick={goBack}>
             <div className="icon-prefix__icon">
               <Icon icon={faChevronLeft} />
@@ -122,34 +60,27 @@ export default class Service extends Component {
             <span className="icon-prefix__label">Go back</span>
           </button>
 
-          {!loading && (
-            <Fragment>
+          {(provider && services) && <Fragment>
               <ServiceProvider
                 provider={provider}
                 userLatitude={userLatitude}
                 userLongitude={userLongitude}
               />
               <Accordion>
-                {services.map((service, i) => {
-                  return (
+                {services.map((service, i) =>
                     <ServiceDetails
                       expanded={i === 0}
-                      key={i}
-                      serviceName={service.SERVICE_NAME}
-                      targetAudiences={service.SERVICE_TARGET_AUDIENCES}
-                      deliveryMethods={service.DELIVERY_METHODS}
-                      serviceReferrals={service.SERVICE_REFERRALS}
-                      costType={service.COST_TYPE}
-                      costDescription={service.COST_DESCRIPTION}
-                      serviceDetail={service.SERVICE_DETAIL}
-                    />
-                  );
-                })}
+                      key={`service_${i}`}
+                      service={service}
+                    />)}
               </Accordion>
-              {providerMap}
-            </Fragment>
-          )}
-        </header>
+              <MapContainer 
+                serviceProviders={[provider]}
+                userLatitude={userLatitude}
+                userLongitude={userLongitude}
+              />
+            </Fragment>}
+        </section>
       </Page>
     );
   }

--- a/src/pages/service.js
+++ b/src/pages/service.js
@@ -21,8 +21,8 @@ export default class Service extends Component {
 
   componentDidMount = async () => {
     const { 
-      userLatitude, 
-      userLongitude,
+      latitude: userLatitude, 
+      longitude: userLongitude,
     } = queryString.parse(this.props.location.search);
 
     const {

--- a/src/utilities/string.js
+++ b/src/utilities/string.js
@@ -1,3 +1,12 @@
 const stripSpaces = string => string.split(' ').join('');
 
-export { stripSpaces };
+// Truncate a string to a given length.
+//
+// Appends a terminator sequence (default ...) if necessary to show a truncation
+// has happened.
+const truncate = (string, target_length, terminator = '...') => 
+  string.length < target_length
+    ? string
+    : string.substring(0, target_length - terminator.length) + terminator;
+
+export { stripSpaces, truncate };

--- a/src/utilities/string.js
+++ b/src/utilities/string.js
@@ -1,12 +1,3 @@
 const stripSpaces = string => string.split(' ').join('');
 
-// Truncate a string to a given length.
-//
-// Appends a terminator sequence (default ...) if necessary to show a truncation
-// has happened.
-const truncate = (string, target_length, terminator = '...') => 
-  string.length < target_length
-    ? string
-    : string.substring(0, target_length - terminator.length) + terminator;
-
-export { stripSpaces, truncate };
+export { stripSpaces };


### PR DESCRIPTION
Closes #267

- Provider purpose in mobile view has been changed to `overflow: scroll` when text is long
- Improved text formatting of provider purpose (will respect line breaks in source text)
- Improved text formatting of provider classification (now has spaces between multiple classifications)
- Refactoring to use a slightly different rendering method for provider search results as compared to the full provider details page (splits common components out into new files)
- Refactoring to reduce the number of lines of code (mostly passing objects as parameters instead of their man properties)
- One of the standard Cucumber tests now finds 28 results rather than 27 (due to a new version of the source data?)
- Fixed some React warnings about needing unique `key` properties

<img width="356" alt="Screen Shot 2019-05-29 at 13 04 16" src="https://user-images.githubusercontent.com/33472821/58530861-65d6d880-8234-11e9-955d-f8a97b11a63f.png">
