### PR TITLE
wrap long text like urls rather than overflowing

### DIFF
--- a/src/assets/scss/components/_icon-prefix.scss
+++ b/src/assets/scss/components/_icon-prefix.scss
@@ -2,6 +2,7 @@
   &__container {
     display: flex;
     justify-content: flex-start;
+    word-break: break-word;
   }
 
   &__icon {

--- a/src/components/service-header.js
+++ b/src/components/service-header.js
@@ -45,8 +45,6 @@ export default class ServiceHeader extends Component {
         ? `https://maps.google.com/maps?saddr=${userLocation.address}&daddr=${address}`
         : `https://maps.google.com/maps?daddr=${address}`
 
-    debugger
-
     return (
       <header className="service__header">
         <h2 className="service__name">

--- a/src/components/service-provider-result.js
+++ b/src/components/service-provider-result.js
@@ -26,7 +26,8 @@ export default class ServiceProviderResult extends Component {
 
     return (
       <section className="service" result-index={index}>
-        {process.env.REACT_APP_DISPLAY_INDEX && index+1 }
+        {process.env.REACT_APP_DISPLAY_INDEX && (<div>{index+1}</div>) }
+        {process.env.REACT_APP_DISPLAY_INDEX && (<div>{provider.rank}</div>) }
         <ServiceHeader
           provider={provider}
           userLocation={userLocation}


### PR DESCRIPTION


Wrap long text like URLs so they don't break out of the layout and enable horizontal scrolling

Also adds the result rank above search results in debug mode (unrelated developer quality of life change)

<img width="292" alt="Screen Shot 2019-06-06 at 10 59 51" src="https://user-images.githubusercontent.com/33472821/58995988-7d245000-884a-11e9-8293-558d8f3d93d8.png">