### PR TITLE
Use the production react app api path and resource id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
       REACT_APP_HOST: https://family.services.govt.nz/
       REACT_APP_GH_PAGES_SUFFIX: /
       REACT_APP_ADDRESS_FINDER_API_KEY: XU3BTFEQHKV9NY8AWDMG
+      REACT_APP_API_PATH: https://catalogue.data.govt.nz/api/3/action/
+      REACT_APP_API_RESOURCE_ID: 35de6bf8-b254-4025-89f5-da9eb6adf9a0
     steps:
       - add_ssh_keys:
           fingerprints:


### PR DESCRIPTION
Currently the build is using the UAT data.govt.nz.
I'm not sure where circle-ci is finding this config from, but let's make it explicit.

<details>
<summary>Screeenshot</summary>

<img width="1275" alt="Screen Shot 2019-09-16 at 10 42 05 AM" src="https://user-images.githubusercontent.com/1615322/64928602-b23f3600-d86e-11e9-92a6-7402a1700a30.png">

</details>