### PR TITLE
IE11 css fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,6 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
-    <div id="footer"></div>
     <link href="https://fonts.googleapis.com/css?family=Fira+Sans:400,700&display=swap" rel="stylesheet">
     <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"
    integrity="sha512-lInM/apFSqyy1o6s89K4iQUKg6ppXEgsVxT35HbzUupEVRh2Eu9Wdl4tHj7dZO0s1uvplcYGmt3498TtHq+log=="

--- a/src/assets/scss/theme/_footer.scss
+++ b/src/assets/scss/theme/_footer.scss
@@ -1,3 +1,6 @@
+footer {
+  display: block; // for IE
+}
 .app__footer {
   position: absolute;
   bottom: 0;

--- a/src/assets/scss/theme/_header.scss
+++ b/src/assets/scss/theme/_header.scss
@@ -1,3 +1,6 @@
+header {
+  display: block; // for IE
+}
 .app__header {
   background-color: $header-bg;
 

--- a/src/assets/scss/theme/_main.scss
+++ b/src/assets/scss/theme/_main.scss
@@ -1,4 +1,5 @@
 main {
+  display: block; // for IE
   margin: 0 auto;
   width: 100%;
   max-width: 50rem;

--- a/src/assets/scss/utilities/_mui_overrides.scss
+++ b/src/assets/scss/utilities/_mui_overrides.scss
@@ -9,6 +9,7 @@
   }
 }
 .MuiButton-containedPrimary {
+  color: $white !important;
   background-color: $blue !important;
   a, a:hover, a:visited {
     color: $white !important;

--- a/src/components/service-provider-result.js
+++ b/src/components/service-provider-result.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import CardActions from '@material-ui/core/CardActions';
-import Button from '@material-ui/core/Button';
 
 import ServiceHeader from './service-header';
 import SaveContact from './save-contact';
@@ -52,11 +51,9 @@ export default class ServiceProviderResult extends Component {
             address={provider.address}
             email={provider.email}
             />
-          <Button>
-            <Link to={`/service/${fsdId}`}>
-              More details
-            </Link>
-          </Button>
+          <Link to={`/service/${fsdId}`} className="MuiButtonBase-root MuiButton-root MuiButton-text">
+            More details
+          </Link>
         </CardActions>
       </Card>
     );

--- a/src/components/service-provider-result.js
+++ b/src/components/service-provider-result.js
@@ -40,15 +40,15 @@ export default class ServiceProviderResult extends Component {
         <div>
         </div>
         <CardActions>
+          <Link to={`/service/${fsdId}`} className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary">
+            More details
+          </Link>
           <SaveContact
             name={mappedProvider.name}
             phoneNumber={mappedProvider.phone}
             address={mappedProvider.address}
             email={mappedProvider.email}
             />
-          <Link to={`/service/${fsdId}`} className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary">
-            More details
-          </Link>
         </CardActions>
       </Card>
     );

--- a/src/components/service-provider-result.js
+++ b/src/components/service-provider-result.js
@@ -40,7 +40,7 @@ export default class ServiceProviderResult extends Component {
         <div>
         </div>
         <CardActions>
-          <Link to={`/service/${mappedProvider.fsdId}`} className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary">
+          <Link to={`/service/${mappedProvider.fsdId}`} className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-contained MuiButton-containedPrimary">
             More details
           </Link>
           <SaveContact

--- a/src/components/service-provider-result.js
+++ b/src/components/service-provider-result.js
@@ -40,7 +40,7 @@ export default class ServiceProviderResult extends Component {
         <div>
         </div>
         <CardActions>
-          <Link to={`/service/${fsdId}`} className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary">
+          <Link to={`/service/${mappedProvider.fsdId}`} className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary">
             More details
           </Link>
           <SaveContact


### PR DESCRIPTION
- Remove unused footer
- Set `display: block` defaults in CSS for unsupported HTML5 elements
- `a` nested under `button` wasn't working properly in IE - give the link the MUI classes instead